### PR TITLE
Use Apache Commons Geometry for BoundingBox implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,9 @@ dependencies {
 
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.10.3'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// https://mvnrepository.com/artifact/org.apache.commons/commons-geometry-euclidean
+	implementation 'org.apache.commons:commons-geometry-euclidean:1.0'
 }
 
 test {

--- a/src/main/java/frc/robot/auto_manager/BoundingBox.java
+++ b/src/main/java/frc/robot/auto_manager/BoundingBox.java
@@ -4,32 +4,36 @@
 
 package frc.robot.auto_manager;
 
-import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import org.apache.commons.geometry.euclidean.twod.Bounds2D;
+import org.apache.commons.geometry.euclidean.twod.Vector2D;
+import org.apache.commons.geometry.euclidean.twod.path.LinePath;
+import org.apache.commons.numbers.core.Precision;
 
 public class BoundingBox {
-
-  private Pose2d[] points;
-
-  public BoundingBox(Pose2d topLeft, Pose2d topRight, Pose2d bottomLeft, Pose2d bottomRight) {
-    points = new Pose2d[] {bottomLeft, topLeft, topRight, bottomRight};
+  private static Vector2D translationToVector(Translation2d translation) {
+    return Vector2D.of(translation.getX(), translation.getY());
   }
 
-  public boolean containsPose(Pose2d pose) {
-    double angleSum = 0;
-    for (int i = 0; i < points.length; i++) {
-      Pose2d corner1 = points[i];
-      Pose2d corner2 = points[(i + 1) % points.length];
-      angleSum += calculateAngle(pose, corner1, corner2);
-    }
+  private final Bounds2D bounds;
 
-    return Math.abs(angleSum - (2 * Math.PI)) < 0.0001;
+  public BoundingBox(
+      Translation2d topLeft,
+      Translation2d topRight,
+      Translation2d bottomLeft,
+      Translation2d bottomRight) {
+    bounds =
+        LinePath.builder(Precision.doubleEquivalenceOfEpsilon(0.01))
+            .appendVertices(
+                translationToVector(topLeft),
+                translationToVector(topRight),
+                translationToVector(bottomRight),
+                translationToVector(bottomLeft))
+            .build()
+            .getBounds();
   }
 
-  private double calculateAngle(Pose2d point, Pose2d corner1, Pose2d corner2) {
-    double a = corner1.getTranslation().getDistance(corner2.getTranslation());
-    double b = corner1.getTranslation().getDistance(point.getTranslation());
-    double c = corner2.getTranslation().getDistance(point.getTranslation());
-    double cosA = (b * b + c * c - a * a) / (2 * b * c);
-    return Math.acos(cosA);
+  public boolean contains(Translation2d translation) {
+    return bounds.contains(translationToVector(translation));
   }
 }

--- a/src/main/java/frc/robot/note_tracking/NoteTrackingManager.java
+++ b/src/main/java/frc/robot/note_tracking/NoteTrackingManager.java
@@ -83,17 +83,15 @@ public class NoteTrackingManager extends LifecycleSubsystem {
         new Pose2d(0.3, -0.3, new Rotation2d())
             .rotateBy(Rotation2d.fromDegrees(robotPose.getRotation().getDegrees()));
 
-    var topLeft =
-        new Pose2d(robotPose.getX() + tLB.getX(), robotPose.getY() + tLB.getY(), new Rotation2d());
-    var topRight =
-        new Pose2d(robotPose.getX() + tRB.getX(), robotPose.getY() + tRB.getY(), new Rotation2d());
+    var topLeft = new Translation2d(robotPose.getX() + tLB.getX(), robotPose.getY() + tLB.getY());
+    var topRight = new Translation2d(robotPose.getX() + tRB.getX(), robotPose.getY() + tRB.getY());
     var bottomLeft =
-        new Pose2d(robotPose.getX() + bLB.getX(), robotPose.getY() + bLB.getY(), new Rotation2d());
+        new Translation2d(robotPose.getX() + bLB.getX(), robotPose.getY() + bLB.getY());
     var bottomRight =
-        new Pose2d(robotPose.getX() + bRB.getX(), robotPose.getY() + bRB.getY(), new Rotation2d());
+        new Translation2d(robotPose.getX() + bRB.getX(), robotPose.getY() + bRB.getY());
 
     var box = new BoundingBox(topLeft, topRight, bottomLeft, bottomRight);
-    return box.containsPose(notePose);
+    return box.contains(notePose.getTranslation());
   }
 
   public void resetNoteMap(ArrayList<NoteMapElement> startingValues) {


### PR DESCRIPTION
Refactors the `BoundingBox` implementation (specifically the logic used in `BoundingBox#contains()`) to make use of Apache Commons Geometry's `LinePath` and `Bounds2d` functionality.

Reasoning for this change is that:
- Their library is (probably, hopefully) using much more performant operations for this than our impl.
- Don't have to write the math ourself 🫡