### PR TITLE
Avoid creating boxed types from CTR StatusSignal

### DIFF
--- a/src/main/java/frc/robot/imu/ImuSubsystem.java
+++ b/src/main/java/frc/robot/imu/ImuSubsystem.java
@@ -60,7 +60,7 @@ public class ImuSubsystem extends LifecycleSubsystem {
   }
 
   public double getRobotHeading() {
-    return MathUtil.inputModulus(imu.getYaw().getValue(), -180, 180);
+    return MathUtil.inputModulus(imu.getYaw().getValueAsDouble(), -180, 180);
   }
 
   public double getRobotHeading(double timestamp) {
@@ -71,19 +71,19 @@ public class ImuSubsystem extends LifecycleSubsystem {
   }
 
   public double getPitch() {
-    return imu.getPitch().getValue();
+    return imu.getPitch().getValueAsDouble();
   }
 
   public double getPitchRate() {
-    return imu.getAngularVelocityYWorld().getValue();
+    return imu.getAngularVelocityYWorld().getValueAsDouble();
   }
 
   public double getRoll() {
-    return imu.getRoll().getValue();
+    return imu.getRoll().getValueAsDouble();
   }
 
   public double getRollRate() {
-    return imu.getAngularVelocityXWorld().getValue();
+    return imu.getAngularVelocityXWorld().getValueAsDouble();
   }
 
   public double getRobotAngularVelocity() {

--- a/src/main/java/frc/robot/shooter/ShooterSubsystem.java
+++ b/src/main/java/frc/robot/shooter/ShooterSubsystem.java
@@ -126,7 +126,7 @@ public class ShooterSubsystem extends LifecycleSubsystem {
   }
 
   private double getRPM(TalonFX motor) {
-    return motor.getVelocity().getValue() * 60.0;
+    return motor.getVelocity().getValueAsDouble() * 60.0;
   }
 
   public void setGoalMode(ShooterMode newMode) {

--- a/src/main/java/frc/robot/wrist/WristSubsystem.java
+++ b/src/main/java/frc/robot/wrist/WristSubsystem.java
@@ -90,7 +90,7 @@ public class WristSubsystem extends LifecycleSubsystem {
         break;
     }
 
-    DogLog.log("Wrist/Position", Units.rotationsToDegrees(motor.getPosition().getValue()));
+    DogLog.log("Wrist/Position", Units.rotationsToDegrees(motor.getPosition().getValueAsDouble()));
     DogLog.log("Wrist/HomingState", homingState);
     DogLog.log("Wrist/GoalAngle", goalAngle);
   }


### PR DESCRIPTION
Avoid creating boxed types with CTR's `StatusSignal#getValue()` method. `getValueAsDouble()` returns the raw double primitive, and avoids any of the evil type casting behavior.